### PR TITLE
makes sure that https request is made correctly

### DIFF
--- a/lib/geolocal/provider/db_ip.rb
+++ b/lib/geolocal/provider/db_ip.rb
@@ -33,11 +33,26 @@ class Geolocal::Provider::DB_IP < Geolocal::Provider::Base
     "#{config[:tmpdir]}/dbip-country.csv.gz"
   end
 
+  def get_launch_page_body(start_url)
+    begin
+      uri = URI start_url
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = true
+      http.verify_mode = OpenSSL::SSL::VERIFY_NONE # Sets the HTTPS verify mode
+      response = http.get(uri.request_uri)
+      raise unless response.code.match(/^2/)
+      response.body
+        
+    rescue
+      raise "unable to access resource: #{START_URL}"
+    end
+  end
+
   def download_files
     # they update the file every month but no idea which day they upload it
     return if up_to_date?(csv_file, 86400)
 
-    page = Net::HTTP.get(URI START_URL)
+    page = get_launch_page_body(START_URL)
 
     # if we used Nokogiri: (we don't since we don't want to force the dependency)
     # doc = Nokogiri::HTML(page)

--- a/spec/geolocal/provider/db_ip_spec.rb
+++ b/spec/geolocal/provider/db_ip_spec.rb
@@ -35,6 +35,18 @@ describe Geolocal::Provider::DB_IP do
         to_return(:status => 200, :body => country_csv, :headers => {'Content-Length' => country_csv.length})
     end
 
+    it 'handles invalid launch page url' do
+      expect{provider.get_launch_page_body(nil)}.to raise_error(/^unable to access/)
+    end
+
+    it 'handles not being able to access download pre-page' do
+      stub_request(:get, 'https://db-ip.com/db/download/country').
+        with(headers: {'Accept'=>'*/*', 'User-Agent'=>'Ruby'}).
+        to_return(status: 404, body: "blah", headers: {})
+
+      expect{provider.download}.to raise_error(/^unable to access/)
+    end
+
     it 'can download the csv' do
       Geolocal.configure do |config|
         config.tmpdir = 'tmp/geolocal-test'


### PR DESCRIPTION
I was getting a [similar error](http://stackoverflow.com/questions/20710170/making-an-api-call-over-ssl-in-ruby#answer-20710225) when attempting to use the gem as advertised.  This seems to make the request more robust.
